### PR TITLE
Let's make fetchSize JdbcTemplate property at the constructor

### DIFF
--- a/src/main/java/com/alexkasko/springjdbc/iterable/IterableJdbcTemplate.java
+++ b/src/main/java/com/alexkasko/springjdbc/iterable/IterableJdbcTemplate.java
@@ -32,6 +32,11 @@ public class IterableJdbcTemplate extends JdbcTemplate implements IterableJdbcOp
         super(dataSource);
     }
 
+    public IterableJdbcTemplate(DataSource dataSource, int fetchSize) {
+        this(dataSource);
+        setFetchSize(fetchSize);
+    }
+
     /**
      * Static method to use in finally methods for closing
      * {@link CloseableIterator}s. Writes warning into log on exception.

--- a/src/main/java/com/alexkasko/springjdbc/iterable/IterableNamedParameterJdbcTemplate.java
+++ b/src/main/java/com/alexkasko/springjdbc/iterable/IterableNamedParameterJdbcTemplate.java
@@ -24,6 +24,10 @@ public class IterableNamedParameterJdbcTemplate extends NamedParameterJdbcTempla
         super(new IterableJdbcTemplate(dataSource));
     }
 
+    public IterableNamedParameterJdbcTemplate(DataSource dataSource, int fetchSize) {
+        super(new IterableJdbcTemplate(dataSource, fetchSize));
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
I think it will be great to have posibility to set fetchSize in the constructor already, because it is very sufficient property for IterableJdbcTemplate.
